### PR TITLE
luci-app-ssr-plus: remove stream ciphers placeholder for v2ray/Xray SS

### DIFF
--- a/luci-app-ssr-plus/luasrc/model/cbi/shadowsocksr/client-config.lua
+++ b/luci-app-ssr-plus/luasrc/model/cbi/shadowsocksr/client-config.lua
@@ -47,6 +47,8 @@ local encrypt_methods_ss = {
 	"chacha20-ietf-poly1305",
 	"xchacha20-ietf-poly1305"
 	--[[ stream
+	"none",
+	"plain",
 	"table",
 	"rc4",
 	"rc4-md5",
@@ -69,11 +71,6 @@ local encrypt_methods_v2ray_ss = {
 	-- xray_ss
 	"none",
 	"plain",
-	--[[ stream
-	"aes-128-cfb",
-	"aes-256-cfb",
-	"chacha20",
-	"chacha20-ietf", ]]
 	-- aead
 	"aes-128-gcm",
 	"aes-256-gcm",


### PR DESCRIPTION
They were removed in both v2ray and Xray, not actually available.
Drop the dead code anyway.